### PR TITLE
[POSTER] TADAM Task dependent adaptive metric for improved few-shot learning

### DIFF
--- a/docs/_pages/papers.md
+++ b/docs/_pages/papers.md
@@ -71,6 +71,7 @@ We add paper to this list if we want to presente it later, or want to ask other 
 
 | Seminar | Member | Paper |
 | ------- | ------ | ----- |
+| [S2E13](https://ai-ml.club/events/seminar-meeting-minutes-2-13/) | [@vdeamov](https://github.com/vdeamov) | [TADAM: Task dependent adaptive metric for improved few-shot learnin, Oreshkin, et. al., 2018](http://papers.nips.cc/paper/7352-tadam-task-dependent-adaptive-metric-for-improved-few-shot-learning.pdf) |
 | [S2E13](https://ai-ml.club/events/seminar-meeting-minutes-2-13/) | [@huan](https://github.com/huan) | [Generating Long Sequences with Sparse Transformers, Rewon Child, et. al., 2019](https://openai.com/blog/sparse-transformer/) |
 | [S2E12](https://ai-ml.club/events/seminar-meeting-minutes-2-12/) | [@huan](https://github.com/huan) | [Speech2Face: Learning the Face Behind a Voice, Tae-Hyun et. al., 2019](https://arxiv.org/pdf/1905.09773.pdf) |
 | [S2E12](https://ai-ml.club/events/seminar-meeting-minutes-2-12/) | [@linbo0518](https://github.com/linbo0518) | [Bag of Tricks for Image Classification with Convolutional Neural Networks, He et al., 2018](https://arxiv.org/abs/1812.01187) |


### PR DESCRIPTION
# AMC Seminar Sign Up

#117 

## 1. Oral / Poster Selection

- [ ] Oral (15 MIN)
- [x] Poster (5 MIN)

## 2. Paper Information

| Paper | Information |
| --- | --- |
| Name | TADAM Task dependent adaptive metric for improved few-shot learning |
| Year | 2018 |
| Publish | NIPS |
| Author | Oreshkin, et. al. |
| GitHub | https://github.com/ElementAI/TADAM |
| Blog | None |
| Arxiv | https://arxiv.org/abs/1805.10123 |

### 3. After Party

- [ ] YES! I'll definitely join the After Party!
- [x] Maybe. I'll decide later...
- [ ] No, I'll not join.

## 4. New Friend

- [x] I'll bring a new friend
- [ ] There's no new friend from me

| Referrer | Newcomer | GitHub | Bio |
| -------- | -------- | ------ | --- |
| @[zhangchurong](https://github.com/zhangchurong) | 张楚镕 | @zhangchurong | OCR |

----------------
<sub>
<i>

Artificial Intelligence & Machine Learning CLUB, 2018 - 2019 <a href="https://ai-ml.club">AI ML Club - AMC</a> <a href="https://github.com/BUPT/ai-ml.club/wiki/Member-Manual">Member Manual</a>

</i>
</sub>