### PR TITLE
Grad-CAM: Visual Explanations from Deep Networks via Gradient-based Localization

### DIFF
--- a/docs/_pages/papers.md
+++ b/docs/_pages/papers.md
@@ -51,6 +51,7 @@ We only add paper to this list before we decide to oral/poster it at our AMC sem
 
 | Seminar | Member | Paper |
 | ------- | ------ | ----- |
+| [S2E20](https://ai-ml.club/events/seminar-meeting-minutes-2-20/) | [@gaojiuy](https://github.com/gaojiuy) | [Grad-CAM: Visual Explanations from Deep Networks via Gradient-based Localization](https://arxiv.org/pdf/1610.02391.pdf) |
 | [S2E19](https://ai-ml.club/events/seminar-meeting-minutes-2-19/) | [@ArronHZG](https://github.com/ArronHZG) | [Attention in computer version](https://blog.csdn.net/Arron_hou/article/details/95676716) |
 | [S2E19](https://ai-ml.club/events/seminar-meeting-minutes-2-19/) | [@WdBlink](https://github.com/wdblink) | [High-Resolution Representations for Labeling Pixels and Regions](https://arxiv.org/abs/1904.04514) |
 | [S2E19](https://ai-ml.club/events/seminar-meeting-minutes-2-19/) | [@secortot](https://github.com/secortot) | [guided anchor](https://arxiv.org/abs/1901.03278) |


### PR DESCRIPTION
> 📰Poster-Grad-CAM:Visual Explanations from Deep Networks via Gradient-based Localization

# AMC Seminar Sign Up

[#201](https://github.com/BUPT/ai-ml.club/issues/201)

## 1. Oral / Poster Selection
- [ ] 🗣 Oral (15 MIN)
- [x] 📰 Poster (5 MIN)

## 2. Paper Information

| Paper | Information |
| --- | --- |
| Name | Grad-CAM:Visual Explanations from Deep Networks via Gradient-based Localization |
| Recommendation |  Grad-CAM, a class-discriminative localization technique that can generate visual explanations from any CNN-based network without requiring architectural changes or re-training.  |
| Year | 2017|
| Author | Ramprasaath R. Selvaraju, et. al. |
| GitHub |[grad-cam](https://github.com/ramprs/grad-cam/)|
| Arxiv | [pdf](https://arxiv.org/pdf/1610.02391.pdf)|

### 3. After Party 🍻

- [ ] 🍻 YES! I'll definitely join the After Party!
- [ ] 🤔 Maybe. I'd like to decide later.
- [x] 🛌 No, I'm afraid not this time.

## 4. New Friend

- [ ] 👥 I'll bring a new friend
- [x] 👤 There's no new friend from me

----------------
<sub>
<i>

Artificial Intelligence & Machine Learning CLUB, 2018 - 2019 <a href="https://ai-ml.club">AI ML Club - AMC</a> <a href="https://ai-ml.club/manuals/member/">Member Manual</a>

</i>
</sub>
