### PR TITLE
Insert HeXin's name in blog author list.

### DIFF
--- a/docs/_data/authors.yml
+++ b/docs/_data/authors.yml
@@ -130,3 +130,10 @@ Jarvisgivemeasuit:
       icon: "fab fa-fw fa-github"
       url: "https://github.com/Jarvisgivemeasuit"
 
+newip:
+  name        : "贺新"
+  bio         : "AI Robot helping people living more efficiency. Welcome to the AI Bot world. (XinRobot is me)"
+  links:
+    - label: "GitHub"
+      icon: "fab fa-fw fa-github"
+      url: "https://github.com/newip"


### PR DESCRIPTION
Insert HeXin's name in blog author list. One problem: the avatar link not found with limited time. 